### PR TITLE
Remove Jenkins test harness from hpi file, require Jenkins 2.361.4 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,10 @@
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(
-  useContainerAgent: true,
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 8],
-    [platform: 'windows', jdk: 8],
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>3.43</version>
+		<version>4.76</version>
 		<relativePath />
 	</parent>
 
@@ -18,11 +18,8 @@
 	<properties>
         <revision>1.29</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.138.4</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.361.4</jenkins.version>
         <no-test-jar>false</no-test-jar>
-        <workflow-cps.version>2.66</workflow-cps.version>
-        <workflow-support.version>3.2</workflow-support.version>
     </properties>
 	<licenses>
 		<license>
@@ -31,7 +28,7 @@
 		</license>
 	</licenses>
 	<scm>
-		<connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+		<connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
 		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 		<tag>${scmTag}</tag>
@@ -60,37 +57,42 @@
         </developer>
     </developers>
     <dependencies>
-    	<dependency>
-    		<groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness-htmlunit</artifactId>
-            <version>2.31-2</version>
-            <scope>compile</scope>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.34</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.56</version>
-        </dependency>
-        <dependency>
-        	<groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>2102.v854b_fec19c92</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
     	<pluginManagement>
     		<plugins>

--- a/src/main/java/org/jenkins_cli/plugins/ifdtms/CucumberGlobalConfiguration.java
+++ b/src/main/java/org/jenkins_cli/plugins/ifdtms/CucumberGlobalConfiguration.java
@@ -1,6 +1,6 @@
 package org.jenkins_cli.plugins.ifdtms;
 
-import hidden.jth.org.apache.http.HttpStatus;
+import org.apache.http.HttpStatus;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;

--- a/src/main/java/org/jenkins_cli/plugins/ifdtms/CucumberPostBuild.java
+++ b/src/main/java/org/jenkins_cli/plugins/ifdtms/CucumberPostBuild.java
@@ -1,6 +1,6 @@
 package org.jenkins_cli.plugins.ifdtms;
 
-import hidden.jth.org.apache.http.HttpStatus;
+import org.apache.http.HttpStatus;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;

--- a/src/main/java/org/jenkins_cli/plugins/ifdtms/rest/RequestApi.java
+++ b/src/main/java/org/jenkins_cli/plugins/ifdtms/rest/RequestApi.java
@@ -1,11 +1,11 @@
 package org.jenkins_cli.plugins.ifdtms.rest;
 
-import hidden.jth.org.apache.http.HttpEntity;
-import hidden.jth.org.apache.http.HttpResponse;
-import hidden.jth.org.apache.http.client.methods.HttpPost;
-import hidden.jth.org.apache.http.entity.StringEntity;
-import hidden.jth.org.apache.http.impl.client.CloseableHttpClient;
-import hidden.jth.org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import net.sf.json.JSONObject;
 
 import java.io.*;


### PR DESCRIPTION
## Require Jenkins 2.361.4 or newer and Java 11

Also removes Jenkins test harness from the plugin packaging

**DOES NOT FIX THE INCORRECT MODIFICATION OF ARTIFACT ID**

https://github.com/jenkinsci/itms-for-jira-plugin/pull/1 needs partial revert to restore original artifact ID and package ID.

## Remove Jenkins test harness HTMLUnit from the plugin hpi file

https://github.com/jenkinsci/jenkins/pull/8714 included in Jenkins 2.434 and later will refuse to load a plugin that includes the Jenkins test harness.

The Jenkins test harness causes unexpected failures when it is included in a Jenkins plugin.  Refer to the following issue reports for examples:

* https://issues.jenkins.io/browse/JENKINS-65650
* https://issues.jenkins.io/browse/JENKINS-66060
* https://issues.jenkins.io/browse/JENKINS-72353

The additional benefit of the change is that it makes the plugin hpi file over 90% smaller.

### Testing done

Confirmed automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
